### PR TITLE
fix: only allow closures for hydration

### DIFF
--- a/FactoryBot/Core/Factory.php
+++ b/FactoryBot/Core/Factory.php
@@ -2,11 +2,11 @@
 
 namespace FactoryBot\Core;
 
+use Closure;
 use FactoryBot\Core\LifecycleHooksObserver;
 use FactoryBot\Exceptions\Exception;
 use FactoryBot\Utils\ClassAnalyser;
 use FactoryBot\Exceptions\InvalidArgumentException;
-use FactoryBot\FactoryBot;
 
 /**
  * Factory class builds hydrates instances of specified models
@@ -155,7 +155,7 @@ class Factory
     private function resolveValue($value)
     {
         $value = is_array($value) ? array_map([$this, "resolveValue"], $value) : $value;
-        return is_callable($value) ? $value($this->classInstance, $this->buildStrategy) : $value;
+        return $value instanceof Closure ? $value($this->classInstance, $this->buildStrategy) : $value;
     }
 
     private function validateDefaultProperties($properties)


### PR DESCRIPTION
is_callable also allows callable methods to be used.

this way a string with test data could potentially collide with a globally available function and the Factory would call it.

e.g. you have a globally available method `help` - if you try to set up test data with the string "help", the factory would call it and pass the `classInstance` and `buildStrategy` resulting in an error or unexpected behavior 